### PR TITLE
loaders raw: fix a compiler warnings on Windows.

### DIFF
--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -78,9 +78,9 @@ unique_ptr<Surface> RawLoader::bitmap()
 
     auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
     surface->buffer = (uint32_t*)(content);
-    surface->stride = w;
-    surface->w = w;
-    surface->h = h;
+    surface->stride = (uint32_t)w;
+    surface->w = (uint32_t)w;
+    surface->h = (uint32_t)h;
     surface->cs = SwCanvas::ARGB8888;
 
     return unique_ptr<Surface>(surface);


### PR DESCRIPTION
fix the invalid conversion from float to uint32_t.
@Issue: https://github.com/Samsung/thorvg/issues/1229

Sync from upstream